### PR TITLE
Ignore case sensitivity in context headers map

### DIFF
--- a/context-propagation-core/src/main/java/org/qubership/cloud/context/propagation/core/contextdata/DeserializedIncomingContextData.java
+++ b/context-propagation-core/src/main/java/org/qubership/cloud/context/propagation/core/contextdata/DeserializedIncomingContextData.java
@@ -2,13 +2,15 @@ package org.qubership.cloud.context.propagation.core.contextdata;
 
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 public class DeserializedIncomingContextData implements IncomingContextData {
 
     private Map<String, Object> data;
 
     public DeserializedIncomingContextData(Map<String, Object> data) {
-        this.data = data;
+        this.data = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        this.data.putAll(data);
     }
 
     @Override

--- a/context-propagation-core/src/main/java/org/qubership/cloud/context/propagation/core/contextdata/DeserializedIncomingContextData.java
+++ b/context-propagation-core/src/main/java/org/qubership/cloud/context/propagation/core/contextdata/DeserializedIncomingContextData.java
@@ -6,10 +6,9 @@ import java.util.TreeMap;
 
 public class DeserializedIncomingContextData implements IncomingContextData {
 
-    private Map<String, Object> data;
+    private final Map<String, Object> data = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     public DeserializedIncomingContextData(Map<String, Object> data) {
-        this.data = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         this.data.putAll(data);
     }
 

--- a/context-propagation-core/src/test/java/org/qubership/cloud/context/propagation/core/contextdata/DeserializedIncomingContextDataTest.java
+++ b/context-propagation-core/src/test/java/org/qubership/cloud/context/propagation/core/contextdata/DeserializedIncomingContextDataTest.java
@@ -10,9 +10,12 @@ class DeserializedIncomingContextDataTest {
     @Test
     void getIncomingData() {
         DeserializedIncomingContextData incomingContextData =
-                new DeserializedIncomingContextData(Map.of("serField", "serData"));
+                new DeserializedIncomingContextData(Map.of(
+                        "serField", "serData",
+                        "X-Test-Case-Header","case-insensitive-header-value"));
 
         Assertions.assertEquals("serData", incomingContextData.get("serField"));
+        Assertions.assertEquals("case-insensitive-header-value", incomingContextData.get("x-test-case-header"));
     }
 
     @Test

--- a/framework-contexts/src/main/java/org/qubership/cloud/framework/contexts/allowedheaders/AllowedHeadersContextObject.java
+++ b/framework-contexts/src/main/java/org/qubership/cloud/framework/contexts/allowedheaders/AllowedHeadersContextObject.java
@@ -10,17 +10,14 @@ import org.qubership.cloud.context.propagation.core.contexts.SerializableDataCon
 import org.qubership.cloud.context.propagation.core.contexts.common.RequestContextObject;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class AllowedHeadersContextObject implements SerializableContext,
         DefaultValueAwareContext<Map<String, String>>, ResponsePropagatableContext, SerializableDataContext {
 
     private List<String> allowedHeaders = Collections.emptyList();
 
-    private Map<String, String> headers = new HashMap<>();
+    private Map<String, String> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     public AllowedHeadersContextObject(@Nullable IncomingContextData contextData, List<String> allowedHeaders) {
         this.allowedHeaders = allowedHeaders;

--- a/framework-contexts/src/test/java/org/qubership/cloud/framework/contexts/allowedheaders/AllowedHeadersContextObjectPropagationTest.java
+++ b/framework-contexts/src/test/java/org/qubership/cloud/framework/contexts/allowedheaders/AllowedHeadersContextObjectPropagationTest.java
@@ -19,7 +19,8 @@ import java.util.Map;
 class AllowedHeadersContextObjectPropagationTest extends AbstractContextTestWithProperties {
     public static final String ALLOWED_HEADER = "allowed_header";
     private static final String CUSTOM_HEADER = "Custom-header-1";
-    static Map<String, String> properties = Map.of("headers.allowed", CUSTOM_HEADER);
+    // set lowered `Custom-Header-1` to check case-insensitivity
+    static Map<String, String> properties = Map.of("headers.allowed", "custom-header-1");
 
     @BeforeAll
     protected static void setup() {

--- a/framework-contexts/src/test/java/org/qubership/cloud/framework/contexts/allowedheaders/AllowedHeadersPropertyTest.java
+++ b/framework-contexts/src/test/java/org/qubership/cloud/framework/contexts/allowedheaders/AllowedHeadersPropertyTest.java
@@ -1,13 +1,15 @@
 package org.qubership.cloud.framework.contexts.allowedheaders;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.qubership.cloud.context.propagation.core.ContextManager;
 import org.qubership.cloud.context.propagation.core.RequestContextPropagation;
 import org.qubership.cloud.framework.contexts.data.ContextDataRequest;
 import org.qubership.cloud.framework.contexts.data.ContextDataResponse;
 import org.qubership.cloud.framework.contexts.helper.AbstractContextTestWithProperties;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
@@ -20,6 +22,16 @@ public class AllowedHeadersPropertyTest extends AbstractContextTestWithPropertie
 
     @SystemStub
     private EnvironmentVariables environmentVariables = new EnvironmentVariables(HEADERS_ENV, CUSTOM_HEADER);
+
+    @BeforeAll
+    static void setup() {
+        System.clearProperty("headers.allowed");
+    }
+
+    @AfterAll
+    static void tearDown() {
+        System.setProperty("headers.allowed", CUSTOM_HEADER);
+    }
 
     @Test
     public void initAllowedHeadersContext() {

--- a/framework-contexts/src/test/java/org/qubership/cloud/framework/contexts/allowedheaders/AllowedHeadersPropertyTest.java
+++ b/framework-contexts/src/test/java/org/qubership/cloud/framework/contexts/allowedheaders/AllowedHeadersPropertyTest.java
@@ -17,20 +17,26 @@ import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 @ExtendWith(SystemStubsExtension.class)
 public class AllowedHeadersPropertyTest extends AbstractContextTestWithProperties {
     public static final String HEADERS_ENV = "headers_allowed";
+    public static final String HEADERS_PROPERTY = "headers.allowed";
     private static final String CUSTOM_HEADER = "Custom-header-1";
     public static final String ALLOWED_HEADER = "allowed_header";
+
+    private static String headersPropertyBackup;
 
     @SystemStub
     private EnvironmentVariables environmentVariables = new EnvironmentVariables(HEADERS_ENV, CUSTOM_HEADER);
 
     @BeforeAll
     static void setup() {
-        System.clearProperty("headers.allowed");
+        headersPropertyBackup = System.getProperty(HEADERS_PROPERTY);
+        System.clearProperty(HEADERS_PROPERTY);
     }
 
     @AfterAll
     static void tearDown() {
-        System.setProperty("headers.allowed", CUSTOM_HEADER);
+        if (headersPropertyBackup != null) {
+            System.setProperty("headers.allowed", headersPropertyBackup);
+        }
     }
 
     @Test

--- a/framework-contexts/src/test/java/org/qubership/cloud/framework/contexts/data/ContextDataRequest.java
+++ b/framework-contexts/src/test/java/org/qubership/cloud/framework/contexts/data/ContextDataRequest.java
@@ -5,12 +5,13 @@ import org.qubership.cloud.context.propagation.core.contextdata.IncomingContextD
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import static jakarta.ws.rs.core.HttpHeaders.ACCEPT_LANGUAGE;
 
 public class ContextDataRequest implements IncomingContextData {
 
-    Map<String, Object> contextDataMap = new HashMap<>();
+    Map<String, Object> contextDataMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     public static final String CUSTOM_HEADER = "Custom-header-1";
     private static final String WRONG_CUSTOM_HEADER = "Custom-header-2";

--- a/framework-contexts/src/test/java/org/qubership/cloud/framework/contexts/data/ContextDataRequest.java
+++ b/framework-contexts/src/test/java/org/qubership/cloud/framework/contexts/data/ContextDataRequest.java
@@ -2,7 +2,6 @@ package org.qubership.cloud.framework.contexts.data;
 
 import org.qubership.cloud.context.propagation.core.contextdata.IncomingContextData;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;

--- a/framework-contexts/src/test/java/org/qubership/cloud/framework/contexts/data/ContextDataResponse.java
+++ b/framework-contexts/src/test/java/org/qubership/cloud/framework/contexts/data/ContextDataResponse.java
@@ -2,7 +2,6 @@ package org.qubership.cloud.framework.contexts.data;
 
 import org.qubership.cloud.context.propagation.core.contextdata.OutgoingContextData;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 

--- a/framework-contexts/src/test/java/org/qubership/cloud/framework/contexts/data/ContextDataResponse.java
+++ b/framework-contexts/src/test/java/org/qubership/cloud/framework/contexts/data/ContextDataResponse.java
@@ -4,10 +4,11 @@ import org.qubership.cloud.context.propagation.core.contextdata.OutgoingContextD
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 public class ContextDataResponse implements OutgoingContextData {
 
-    private Map<String, Object> responseHeaders = new HashMap<>();
+    private Map<String, Object> responseHeaders = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     @Override
     public void set(String name, Object values) {

--- a/spring-context-aggregator/context-propagation-spring-kafka/src/main/java/org/qubership/cloud/context/propagation/spring/kafka/KafkaContextPropagation.java
+++ b/spring-context-aggregator/context-propagation-spring-kafka/src/main/java/org/qubership/cloud/context/propagation/spring/kafka/KafkaContextPropagation.java
@@ -52,10 +52,9 @@ public class KafkaContextPropagation {
 	}
 
 	static class HeadersAdapter implements IncomingContextData {
-		final Map<String, Object> headers;
+		final Map<String, Object> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
 		public HeadersAdapter(Iterable<Header> headers) {
-			this.headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 			for(Header header : headers) {
 				this.headers.put(header.key(), new String(header.value(), StandardCharsets.UTF_8));
 			}

--- a/spring-context-aggregator/context-propagation-spring-kafka/src/main/java/org/qubership/cloud/context/propagation/spring/kafka/KafkaContextPropagation.java
+++ b/spring-context-aggregator/context-propagation-spring-kafka/src/main/java/org/qubership/cloud/context/propagation/spring/kafka/KafkaContextPropagation.java
@@ -55,7 +55,7 @@ public class KafkaContextPropagation {
 		final Map<String, Object> headers;
 
 		public HeadersAdapter(Iterable<Header> headers) {
-			this.headers = new HashMap<>();
+			this.headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 			for(Header header : headers) {
 				this.headers.put(header.key(), new String(header.value(), StandardCharsets.UTF_8));
 			}

--- a/spring-context-aggregator/context-propagation-spring-kafka/src/test/java/org/qubership/cloud/context/propagation/spring/kafka/ContextPropagationTest.java
+++ b/spring-context-aggregator/context-propagation-spring-kafka/src/test/java/org/qubership/cloud/context/propagation/spring/kafka/ContextPropagationTest.java
@@ -50,7 +50,7 @@ public class ContextPropagationTest {
 
 	@BeforeAll
 	static void setup() {
-		System.setProperty("headers.allowed", CUSTOM_HEADER);
+		System.setProperty("headers.allowed", CUSTOM_HEADER.toLowerCase());
 	}
 
 	@AfterAll

--- a/spring-context-aggregator/context-propagation-spring-rabbit/src/main/java/org/qubership/cloud/context/propagation/spring/rabbit/RabbitContextPropagation.java
+++ b/spring-context-aggregator/context-propagation-spring-rabbit/src/main/java/org/qubership/cloud/context/propagation/spring/rabbit/RabbitContextPropagation.java
@@ -77,10 +77,9 @@ public class RabbitContextPropagation {
 	}
 
 	static class MessageIncomingContextData implements IncomingContextData {
-		final Map<String, Object> headers;
+		final Map<String, Object> headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
 		public MessageIncomingContextData(Map<String, Object> src) {
-			this.headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 			this.headers.putAll(src);
 		}
 

--- a/spring-context-aggregator/context-propagation-spring-rabbit/src/main/java/org/qubership/cloud/context/propagation/spring/rabbit/RabbitContextPropagation.java
+++ b/spring-context-aggregator/context-propagation-spring-rabbit/src/main/java/org/qubership/cloud/context/propagation/spring/rabbit/RabbitContextPropagation.java
@@ -6,10 +6,7 @@ import org.qubership.cloud.context.propagation.core.contextdata.OutgoingContextD
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Delivery;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.BiConsumer;
 
 /**
@@ -83,7 +80,8 @@ public class RabbitContextPropagation {
 		final Map<String, Object> headers;
 
 		public MessageIncomingContextData(Map<String, Object> src) {
-			this.headers = src;
+			this.headers = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+			this.headers.putAll(src);
 		}
 
 		@Override

--- a/spring-context-aggregator/context-propagation-spring-rabbit/src/test/java/org/qubership/cloud/context/propagation/spring/rabbit/PropagationTest.java
+++ b/spring-context-aggregator/context-propagation-spring-rabbit/src/test/java/org/qubership/cloud/context/propagation/spring/rabbit/PropagationTest.java
@@ -75,7 +75,7 @@ public class PropagationTest {
 			channel.queueDeclare("orders", true, false, false, null);
 			channel.queueBind("orders", "orders", "invoice");
 		}
-		System.setProperty("headers.allowed", CUSTOM_HEADER);
+		System.setProperty("headers.allowed", CUSTOM_HEADER.toLowerCase());
 	}
 
     @AfterAll


### PR DESCRIPTION
### Change list:
- Used `TreeMap` with `String.CASE_INSENSITIVE_ORDER` comparator to match headers in contexts without case sensitivity

### Testing:
- Extended unit-tests